### PR TITLE
remove div. by zero in lqcost.h

### DIFF
--- a/lib/systems/costs/lqcost.h
+++ b/lib/systems/costs/lqcost.h
@@ -224,7 +224,7 @@ namespace gcop {
                                             Matrix<double, _np, 1> *Lp, Matrix<double, _np, _np> *Lpp,
                                             Matrix<double, _np, _nx> *Lpx) {
     
-    int k = round(t/h);
+    int k = (h > 0.0) ? round(t/h) : 0 ;
     
         // check if final state
     if (t > this->tf - 1e-10) {


### PR DESCRIPTION
Removed division by zero. 
With this fix, the division t/h is either possible or otherwise k is set to 0.0. 

Bug detected by including fenv.h and  calling feenableexcept(FE_DIVBYZERO)
